### PR TITLE
!pip to %pip

### DIFF
--- a/examples/agent_api_example.ipynb
+++ b/examples/agent_api_example.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install multion -U"
+    "%pip install multion -U"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install IPython requests"
+    "%pip install IPython requests"
    ]
   },
   {


### PR DESCRIPTION
Jupyter recommends

Use '%pip install' instead of '!pip install'Jupyter
'!pip install' could install packages into the wrong environment. More info

https://github.com/microsoft/vscode-jupyter/wiki/Installing-Python-packages-in-Jupyter-Notebooks